### PR TITLE
Call method on actual instance instead of class.

### DIFF
--- a/Sioen/Converter.php
+++ b/Sioen/Converter.php
@@ -50,10 +50,10 @@ class Converter
         foreach ($input['data'] as $block) {
             // check if we have a converter for this type
             $converter = $block['type'] . 'ToHtml';
-            if (is_callable(array(__CLASS__, $converter))) {
+            if (is_callable(array($this, $converter))) {
                 // call the function and add the data as parameters
                 $html .= call_user_func_array(
-                    array(__CLASS__, $converter),
+                    array($this, $converter),
                     $block['data']
                 );
             } elseif (array_key_exists('text', $block['data'])) {


### PR DESCRIPTION
Use of `__CLASS__` disallows extending of `Sioen\Converter` class. Original methods are executed instead of methods which override them. Methods not defined on `Sioen\Converter` were not found on extending class.

Since `toHtml` cannot be called staticaly, call method on instance.
