### PR TITLE
Fix Exception namespace.

### DIFF
--- a/Sioen/Converter.php
+++ b/Sioen/Converter.php
@@ -2,6 +2,7 @@
 
 namespace Sioen;
 
+use Exception;
 use \Michelf\Markdown;
 
 /**


### PR DESCRIPTION
Method `toHtml` may throw `Sioen\Exception` which is not defined.
Added statement to use base `\Exception` instead.
