### PR TITLE
Stop the escaping of Unicode characters in Html to Json conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /vendor/*
 /bin/*
 .DS_Store
-composer.lock
+composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ~*
 /vendor/*
 /bin/*
+.DS_Store
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3",
         "michelf/php-markdown": "1.3.*@dev",
-        "nickcernis/html-to-markdown": "2.1.*@dev"
+        "league/html-to-markdown": "2.1.*@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "woutersioen/sir-trevor-php",
+    "name": "irishdistillers/sir-trevor-php",
     "type": "library",
     "description": "A Sir Trevor to HTML conversion helper for PHP",
     "keywords": ["Sir Trevor", "Sir", "Trevor", "Sir Trevor JS", "html"],
-    "homepage": "https://github.com/woutersioen/sir-trevor-php",
+    "homepage": "https://github.com/irishdistillers/sir-trevor-php",
     "license": "MIT",
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,54 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e30d9a600596d8710bb996932c21ae72",
-    "content-hash": "f1c9be7ca9df3b75ff94930bde820b21",
+    "content-hash": "4372bbc30e71ffbd5eeb3289cb9010d9",
     "packages": [
+        {
+            "name": "league/html-to-markdown",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "c27833198b2777da43455829439cb24287597218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/c27833198b2777da43455829439cb24287597218",
+                "reference": "c27833198b2777da43455829439cb24287597218",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "php": ">=5.3.3",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "HTML_To_Markdown.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/nickcernis/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "time": "2015-01-04T20:10:30+00:00"
+        },
         {
             "name": "michelf/php-markdown",
             "version": "1.3",
@@ -56,54 +101,7 @@
             "keywords": [
                 "markdown"
             ],
-            "time": "2013-04-11 18:53:11"
-        },
-        {
-            "name": "nickcernis/html-to-markdown",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nickcernis/html-to-markdown.git",
-                "reference": "4e8f36f2eccc3f14bb9ba511b0010d70926a2917"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nickcernis/html-to-markdown/zipball/4e8f36f2eccc3f14bb9ba511b0010d70926a2917",
-                "reference": "4e8f36f2eccc3f14bb9ba511b0010d70926a2917",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "php": ">=5.3.3",
-                "phpunit/phpunit": "3.7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "HTML_To_Markdown.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nick Cernis",
-                    "email": "nick@cern.is",
-                    "homepage": "http://modernnerd.net"
-                }
-            ],
-            "description": "An HTML-to-markdown conversion helper for PHP",
-            "homepage": "https://github.com/nickcernis/html-to-markdown",
-            "keywords": [
-                "html",
-                "markdown"
-            ],
-            "abandoned": "league/html-to-markdown",
-            "time": "2013-11-02 11:38:45"
+            "time": "2013-04-11T18:53:11+00:00"
         }
     ],
     "packages-dev": [
@@ -159,41 +157,90 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27T11:43:31+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -205,39 +252,88 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.6.0",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-11-25T06:54:22+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1",
-                "sebastian/recursion-context": "~1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -270,7 +366,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -332,20 +428,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -379,7 +475,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -420,24 +516,27 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
             },
             "type": "library",
             "autoload": {
@@ -461,20 +560,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -510,20 +609,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.24",
+            "version": "4.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1066c562c52900a142a0e2bbf0582994671385e"
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1066c562c52900a142a0e2bbf0582994671385e",
-                "reference": "a1066c562c52900a142a0e2bbf0582994671385e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
                 "shasum": ""
             },
             "require": {
@@ -537,9 +636,9 @@
                 "phpunit/php-code-coverage": "~2.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": ">=1.0.6",
+                "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
@@ -582,7 +681,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-03-14 06:16:08"
+            "time": "2016-12-09T02:45:31+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -638,26 +737,26 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -702,7 +801,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19T09:18:40+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -754,27 +853,27 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.5",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -804,20 +903,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-02-26 18:40:46"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
                 "shasum": ""
             },
             "require": {
@@ -825,12 +924,13 @@
                 "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
+                "ext-mbstring": "*",
                 "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -870,7 +970,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -921,7 +1021,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -974,7 +1074,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1009,30 +1109,35 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.4",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb"
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/584e52cb8f788a887553ba82db6caacb1d6260bb",
-                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
-            "time": "2016-03-04 07:54:35",
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1058,14 +1163,65 @@
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com"
+            "homepage": "https://symfony.com",
+            "time": "2016-12-10T10:07:06+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "michelf/php-markdown": 20,
-        "nickcernis/html-to-markdown": 20
+        "league/html-to-markdown": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Sioen/HtmlToJson.php
+++ b/src/Sioen/HtmlToJson.php
@@ -51,7 +51,7 @@ final class HtmlToJson
             }
         }
 
-        return json_encode(array('data' => $data));
+        return json_encode(array('data' => $data), JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/src/Sioen/HtmlToJson.php
+++ b/src/Sioen/HtmlToJson.php
@@ -35,6 +35,7 @@ final class HtmlToJson
         $html = preg_replace('~>\s+<~', '><', $html);
         $document = new \DOMDocument();
 
+        libxml_use_internal_errors(true);
         // Load UTF-8 HTML hack (from http://bit.ly/pVDyCt)
         $document->loadHTML('<?xml encoding="UTF-8">' . $html);
         $document->encoding = 'UTF-8';

--- a/src/Sioen/HtmlToJson/HtmlToMarkdown.php
+++ b/src/Sioen/HtmlToJson/HtmlToMarkdown.php
@@ -14,7 +14,7 @@ trait HtmlToMarkdown
             $html,
             array(
                 'header_style' => 'atx',
-                'bold_style' => '__',
+                'bold_style' => '**',
                 'italic_style' => '_',
             )
         );

--- a/src/Sioen/HtmlToJson/ListConverter.php
+++ b/src/Sioen/HtmlToJson/ListConverter.php
@@ -10,14 +10,25 @@ final class ListConverter implements Converter
 
     public function toJson(\DOMElement $node)
     {
-        $markdown = $this->htmlToMarkdown($node->ownerDocument->saveXML($node));
+        $list = $node->ownerDocument->saveXML($node);
+        $list = str_replace('<ul>', '', $list);
+        $list = str_replace('</ul>', '', $list);
+        $list = str_replace('</li>', '', $list);
+        $array = explode("<li>", $list);
 
-        // we need a space in the beginning of each line
-        $markdown = ' ' . str_replace("\n", "\n ", $markdown);
+        $listItems = [];
+        foreach($array as $key => $item){
+            if(!empty($item)){
+                $object = (object) [
+                    'content' => $item
+                ];
+                array_push($listItems,$object);
+            }
+        }
 
         return new SirTrevorBlock(
             'list',
-            array('text' => $markdown)
+            array("format"=> "html", 'listItems' => $listItems)
         );
     }
 

--- a/src/Sioen/JsonToHtml/BodyConverter.php
+++ b/src/Sioen/JsonToHtml/BodyConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class BodyConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Body</strong></p>'.$data['text'];
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'body';
+    }
+}

--- a/src/Sioen/JsonToHtml/ColourConverter.php
+++ b/src/Sioen/JsonToHtml/ColourConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class ColourConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Colour</strong></p>'.$data['text'];
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'colour';
+    }
+}

--- a/src/Sioen/JsonToHtml/FinishConverter.php
+++ b/src/Sioen/JsonToHtml/FinishConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class FinishConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Finish</strong></p>'.$data['text'];
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'finish';
+    }
+}

--- a/src/Sioen/JsonToHtml/GoogleMapsConverter.php
+++ b/src/Sioen/JsonToHtml/GoogleMapsConverter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class GoogleMapsConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        return sprintf(
+            '<iframe src="https://www.google.com/maps?q=%s,%s&output=embed" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>',
+            $data['lat'],
+            $data['lng']
+        );
+    }
+
+    public function matches($type)
+    {
+        return $type === 'google_maps';
+    }
+}

--- a/src/Sioen/JsonToHtml/IngredientsConverter.php
+++ b/src/Sioen/JsonToHtml/IngredientsConverter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class IngredientsConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Ingredients</strong></p>';
+        $html .= '<ul>';
+        foreach ($data['listItems'] as $listItem) {
+            $html .= '<li>'.$listItem['content'].'</li>';
+        }
+        $html .= '</ul>';
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'ingredients';
+    }
+}

--- a/src/Sioen/JsonToHtml/IngredientsConverter.php
+++ b/src/Sioen/JsonToHtml/IngredientsConverter.php
@@ -9,7 +9,7 @@ final class IngredientsConverter implements Converter
         $html = '<p><strong>Ingredients</strong></p>';
         $html .= '<ul>';
         foreach ($data['listItems'] as $listItem) {
-            $html .= '<li>'.$listItem['content'].'</li>';
+            $html .= '<li itemprop="recipeIngredient">'.$listItem['content'].'</li>';
         }
         $html .= '</ul>';
         return $html;

--- a/src/Sioen/JsonToHtml/ListConverter.php
+++ b/src/Sioen/JsonToHtml/ListConverter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class ListConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<ul>';
+        foreach ($data['listItems'] as $listItem) {
+            $html .= '<li>'.$listItem['content'].'</li>';
+        }
+        $html .= '</ul>';
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'list';
+    }
+}

--- a/src/Sioen/JsonToHtml/MethodConverter.php
+++ b/src/Sioen/JsonToHtml/MethodConverter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class MethodConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Method</strong></p>';
+        $html .= '<ul>';
+        foreach ($data['listItems'] as $listItem) {
+            $html .= '<li>'.$listItem['content'].'</li>';
+        }
+        $html .= '</ul>';
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'method';
+    }
+}

--- a/src/Sioen/JsonToHtml/MethodConverter.php
+++ b/src/Sioen/JsonToHtml/MethodConverter.php
@@ -6,7 +6,7 @@ final class MethodConverter implements Converter
 {
     public function toHtml(array $data)
     {
-        $html = '<p><strong>Method</strong></p>';
+        $html = '<p itemprop="recipeInstructions"><strong>How to Mix</strong></p>';
         $html .= '<ul>';
         foreach ($data['listItems'] as $listItem) {
             $html .= '<li>'.$listItem['content'].'</li>';

--- a/src/Sioen/JsonToHtml/NoseConverter.php
+++ b/src/Sioen/JsonToHtml/NoseConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class NoseConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Nose</strong></p>'.$data['text'];
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'nose';
+    }
+}

--- a/src/Sioen/JsonToHtml/SoundcloudConverter.php
+++ b/src/Sioen/JsonToHtml/SoundcloudConverter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class SoundcloudConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        return $data['html'];
+    }
+
+    public function matches($type)
+    {
+        return $type === 'soundcloud';
+    }
+}

--- a/src/Sioen/JsonToHtml/TasteConverter.php
+++ b/src/Sioen/JsonToHtml/TasteConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class TasteConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        $html = '<p><strong>Taste</strong></p>'.$data['text'];
+        return $html;
+    }
+
+    public function matches($type)
+    {
+        return $type === 'taste';
+    }
+}

--- a/src/Sioen/JsonToHtml/YoutubeConverter.php
+++ b/src/Sioen/JsonToHtml/YoutubeConverter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sioen\JsonToHtml;
+
+final class YoutubeConverter implements Converter
+{
+    public function toHtml(array $data)
+    {
+        return sprintf(
+            '<iframe src="//www.youtube.com/embed/%s?rel=0" frameborder="0" allowfullscreen></iframe>',
+            $data['remote_id']
+        );
+    }
+
+    public function matches($type)
+    {
+        return $type === 'youtube';
+    }
+}


### PR DESCRIPTION
The json_encode's default behaviour escapes the multibyte unicode characters as \uXXXX. This is problematic for multi-lingual content (especially Japanese). In our opinion, the responsibility of handling the display and storage of these characters should be done in the application using this library.
